### PR TITLE
Standard theme: Touchpad tweaks

### DIFF
--- a/art/standard/gamepad/ouya/touchpad.svg
+++ b/art/standard/gamepad/ouya/touchpad.svg
@@ -1,4 +1,4 @@
-<svg width="100px" height="100px" preserveAspectRatio="none" version="1.1" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+<svg width="70px" height="70px" preserveAspectRatio="none" version="1.1" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
  <defs>
   <linearGradient id="Gradient_1" x1="42.262" x2="86.138" y1="95.875" y2="3.225" gradientUnits="userSpaceOnUse">
    <stop stop-color="#272727" offset="0"/>

--- a/art/standard/gamepad/ps5/touchpad.svg
+++ b/art/standard/gamepad/ps5/touchpad.svg
@@ -1,4 +1,4 @@
-<svg width="100px" height="100px" preserveAspectRatio="none" version="1.1" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+<svg width="120px" height="120px" preserveAspectRatio="none" version="1.1" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
  <defs>
   <linearGradient id="Gradient_1" x1="50.55" x2="50.55" y1="43.088" y2="32.712" gradientUnits="userSpaceOnUse">
    <stop stop-color="#BCBFC4" offset="0"/>


### PR DESCRIPTION
Reduced Ouya touchpad size from 100x100 px to 70x70, increased PS5 touchpad from 100x100 to 120x120, both tweaks done by just changing the "width" and "height" fields of those in Notepad. It did work when opening SVGs in a browser, but needs actual testing in the test program as `make-controllerimage-data` refused to work on my end (I probably compiled something wrong) so I might've overshot (or undershot) both size changes
Should close #26 
