### PR TITLE
Update to SDL3 stable API

### DIFF
--- a/src/controllerimage.c
+++ b/src/controllerimage.c
@@ -114,7 +114,7 @@ void ControllerImage_Quit(void)
     NumCachedStrings = 0;
 }
 
-static SDL_bool readstr(const Uint8 **_ptr, size_t *_buflen, char **_str)
+static bool readstr(const Uint8 **_ptr, size_t *_buflen, char **_str)
 {
     const Uint8 *ptr = *_ptr;
     const size_t total = *_buflen;
@@ -133,12 +133,12 @@ static SDL_bool readstr(const Uint8 **_ptr, size_t *_buflen, char **_str)
             if (!finalstr) {
                 void *expanded = SDL_realloc(StringCache, (NumCachedStrings + 1) * sizeof (char *));
                 if (!expanded) {
-                    return SDL_FALSE;
+                    return false;
                 }
                 StringCache = (char **) expanded;
                 finalstr = SDL_strdup((const char *) ptr);
                 if (!finalstr) {
-                    return SDL_FALSE;
+                    return false;
                 }
 
                 StringCache[NumCachedStrings++] = finalstr;
@@ -147,26 +147,26 @@ static SDL_bool readstr(const Uint8 **_ptr, size_t *_buflen, char **_str)
             *_str = finalstr;
             *_buflen -= i;
             *_ptr += i;
-            return SDL_TRUE;
+            return true;
         }
     }
 
     SDL_SetError("Unexpected end of data");
-    return SDL_FALSE;
+    return false;
 }
 
-static SDL_bool readui16(const Uint8 **_ptr, size_t *_buflen, Uint16 *_ui16)
+static bool readui16(const Uint8 **_ptr, size_t *_buflen, Uint16 *_ui16)
 {
     if (*_buflen < 2) {
         SDL_SetError("Unexpected end of data");
-        return SDL_FALSE;
+        return false;
     }
 
     const Uint8 *ptr = *_ptr;
     *_ui16 = (((Uint16) ptr[0]) << 8) | ((Uint16) ptr[1]);
     *_ptr += 2;
     *_buflen -= 2;
-    return SDL_TRUE;
+    return true;
 }
 
 static void SDLCALL CleanupDeviceInfo(void *userdata, void *value)
@@ -315,7 +315,7 @@ failed:
     return -1;
 }
 
-int ControllerImage_AddDataFromIOStream(SDL_IOStream *iostrm, SDL_bool freeio)
+int ControllerImage_AddDataFromIOStream(SDL_IOStream *iostrm, bool freeio)
 {
     Uint8 *buf = NULL;
     size_t buflen = 0;
@@ -334,7 +334,7 @@ int ControllerImage_AddDataFromIOStream(SDL_IOStream *iostrm, SDL_bool freeio)
 int ControllerImage_AddDataFromFile(const char *fname)
 {
     SDL_IOStream *iostrm = SDL_IOFromFile(fname, "rb");
-    return iostrm ? ControllerImage_AddDataFromIOStream(iostrm, SDL_TRUE) : -1;
+    return iostrm ? ControllerImage_AddDataFromIOStream(iostrm, true) : -1;
 }
 
 static void CollectGamepadImages(ControllerImage_DeviceInfo *info, char **axes, char **buttons)

--- a/src/controllerimage.c
+++ b/src/controllerimage.c
@@ -281,10 +281,7 @@ int ControllerImage_AddData(const void *buf, size_t buflen)
             buflen -= sizeof (guid.data);
 
             char guidstr[33];
-            if (SDL_GUIDToString(guid, guidstr, sizeof (guidstr)) < 0) {
-                SDL_assert(!"this probably shouldn't fail...");
-                goto bogus_data;
-            }
+            SDL_GUIDToString(guid, guidstr, sizeof (guidstr));
 
             // If this fails for some reason, go on without this guid.
 

--- a/src/controllerimage.h
+++ b/src/controllerimage.h
@@ -45,7 +45,7 @@ typedef struct ControllerImage_Device ControllerImage_Device;
 extern SDL_DECLSPEC int SDLCALL ControllerImage_Init(void);
 
 extern SDL_DECLSPEC int SDLCALL ControllerImage_AddData(const void *buf, size_t buflen);
-extern SDL_DECLSPEC int SDLCALL ControllerImage_AddDataFromIOStream(SDL_IOStream *iostrm, SDL_bool freeio);
+extern SDL_DECLSPEC int SDLCALL ControllerImage_AddDataFromIOStream(SDL_IOStream *iostrm, bool freeio);
 extern SDL_DECLSPEC int SDLCALL ControllerImage_AddDataFromFile(const char *fname);
 
 extern SDL_DECLSPEC ControllerImage_Device * SDLCALL ControllerImage_CreateGamepadDevice(SDL_Gamepad *gamepad);

--- a/src/demo-controllerimage.c
+++ b/src/demo-controllerimage.c
@@ -96,7 +96,7 @@ static void LoadControllerImages(ControllerImage_Device *imgdev, SDL_Texture **t
     }
 }
 
-int SDL_AppInit(void **appstate, int argc, char *argv[])
+SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
 {
     SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMEPAD);
 
@@ -169,7 +169,7 @@ int SDL_AppInit(void **appstate, int argc, char *argv[])
 
     SDL_ShowWindow(window);
 
-    return 0;
+    return SDL_APP_CONTINUE;
 }
 
 typedef void(*IterateFn)(void);
@@ -320,7 +320,7 @@ static IterateFn iterate_funcs[] = {
 
 static int current_iterate_func = 0;
 
-int SDL_AppEvent(void *appstate, const SDL_Event *event)
+SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
 {
     switch (event->type) {
         case SDL_EVENT_MOUSE_MOTION:
@@ -329,7 +329,7 @@ int SDL_AppEvent(void *appstate, const SDL_Event *event)
             break;
 
         case SDL_EVENT_QUIT:
-            return 1;  // we're done.
+            return SDL_APP_SUCCESS;  // we're done.
 
         case SDL_EVENT_GAMEPAD_ADDED:
             //LoadControllerImages(ControllerImage_CreateGamepadDeviceByInstance(event->gdevice.which));
@@ -346,7 +346,7 @@ int SDL_AppEvent(void *appstate, const SDL_Event *event)
             break;
 
         case SDL_EVENT_KEY_DOWN:
-            switch (event->key.keysym.sym) {
+            switch (event->key.key) {
                 case SDLK_RIGHT:
                     current_iterate_func++;
                     if (current_iterate_func >= SDL_arraysize(iterate_funcs)) {
@@ -365,19 +365,19 @@ int SDL_AppEvent(void *appstate, const SDL_Event *event)
                     selected_controller = -1;
                     break;
 
-                case SDLK_n:
+                case SDLK_N:
                     selected_controller = -1;
                     break;
 
-                case SDLK_x:
+                case SDLK_X:
                     selected_controller = 0;
                     break;
 
-                case SDLK_p:
+                case SDLK_P:
                     selected_controller = 1;
                     break;
 
-                case SDLK_f:
+                case SDLK_F:
                     do_flood++;
                     if (do_flood == 3) {
                         for (int i = 0; i < MAX_FLOOD_TEXTURES; i++) {
@@ -405,10 +405,10 @@ int SDL_AppEvent(void *appstate, const SDL_Event *event)
         default: break;
     }
 
-    return 0;
+    return SDL_APP_CONTINUE;
 }
 
-int SDL_AppIterate(void *appstate)
+SDL_AppResult SDL_AppIterate(void *appstate)
 {
     SDL_SetRenderDrawColor(renderer, 127, 127, 127, 255);
     SDL_RenderClear(renderer);
@@ -418,10 +418,10 @@ int SDL_AppIterate(void *appstate)
     }
 
     SDL_RenderPresent(renderer);
-    return 0;
+    return SDL_APP_CONTINUE;
 }
 
-void SDL_AppQuit(void *appstate)
+void SDL_AppQuit(void *appstate, SDL_AppResult result)
 {
     for (int i = 0; i < MAX_FLOOD_TEXTURES; i++) {
         SDL_DestroyTexture(xbox_textures[i]);

--- a/src/test-controllerimage.c
+++ b/src/test-controllerimage.c
@@ -76,7 +76,7 @@ int SDL_AppInit(void **appstate, int argc, char *argv[])
     const char *title = argv[0] ? argv[0] : "test-controllerimage";
     SDL_Surface *surf = NULL;
     const char *artset = NULL;
-    SDL_bool added_database = SDL_FALSE;
+    bool added_database = false;
     int i;
 
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMEPAD) < 0) {
@@ -121,7 +121,7 @@ int SDL_AppInit(void **appstate, int argc, char *argv[])
                 if (ControllerImage_AddDataFromFile(arg) < 0) {
                     return panic("ControllerImage_AddDataFromFile failed!", SDL_GetError());
                 }
-                added_database = SDL_TRUE;
+                added_database = true;
             } else if (SDL_strcmp(arg, "dumptheme") == 0) {
                 dump_theme = 0;
                 dump_theme_title = argv[++i];
@@ -325,7 +325,7 @@ int SDL_AppIterate(void *appstate)
     const int w = 512;
     const int h = 317;
 
-    const SDL_bool dumping = (dump_theme >= 0);
+    const bool dumping = (dump_theme >= 0);
     const float scale = (((float) winw) / ((float) w));
     const float fh = ((float) h) * scale;
     const float fy = (((float) winh) - fh) / 2.0f;

--- a/src/test-controllerimage.c
+++ b/src/test-controllerimage.c
@@ -79,7 +79,7 @@ int SDL_AppInit(void **appstate, int argc, char *argv[])
     bool added_database = false;
     int i;
 
-    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMEPAD) < 0) {
+    if (!SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMEPAD)) {
         return panic("SDL_Init failed!", SDL_GetError());
     } else if (ControllerImage_Init() < 0) {
         return panic("ControllerImage_Init failed!", SDL_GetError());


### PR DESCRIPTION
I'm looking forward to trying SDL3 and ControllerImage (thank you). I updated ControllerImage to the SDL3 stable API to the best of my knowledge but no hard feelings if you'd rather update it yourself.

SDL_migration.cocci was run, manually renamed SDL3 unstable API functions/types, and updated app callback signatures and return values. The three applications work (test, demo, make-controllerimage).