### PR TITLE
Make test and demo use V-sync

### DIFF
--- a/src/demo-controllerimage.c
+++ b/src/demo-controllerimage.c
@@ -105,6 +105,7 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
 
     window = SDL_CreateWindow(argv[0], winw, winh, SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIDDEN);
     renderer = SDL_CreateRenderer(window, NULL);
+    SDL_SetRenderVSync(renderer, 1);
 
     ControllerImage_Init();
 

--- a/src/test-controllerimage.c
+++ b/src/test-controllerimage.c
@@ -149,6 +149,7 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
         }
     }
 
+    SDL_SetRenderVSync(renderer, 1);
     SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
     SDL_RenderClear(renderer);
     SDL_RenderPresent(renderer);


### PR DESCRIPTION
Fixes flood mode in the demo and uses less system resources.