### PR TITLE
More updates for SDL3 stable API and misc fixes

### DIFF
--- a/src/controllerimage.c
+++ b/src/controllerimage.c
@@ -537,11 +537,11 @@ void ControllerImage_DestroyDevice(ControllerImage_Device *device)
     if (device) {
         nsvgDeleteRasterizer(device->rasterizer);
         for (int i = 0; i < SDL_GAMEPAD_AXIS_COUNT; i++) {
-	        nsvgDelete(device->axes[i]);
+            nsvgDelete(device->axes[i]);
             SDL_free(device->axes_svg[i]);
         }
         for (int i = 0; i < SDL_GAMEPAD_BUTTON_COUNT; i++) {
-	        nsvgDelete(device->buttons[i]);
+            nsvgDelete(device->buttons[i]);
             SDL_free(device->buttons_svg[i]);
         }
     }
@@ -559,7 +559,7 @@ static SDL_Surface *RasterizeImage(NSVGrasterizer *rasterizer, NSVGimage *image,
     const float scale = (float)size / image->width;
 
     SDL_assert(rasterizer != NULL);
-	nsvgRasterize(rasterizer, image, 0.0f, 0.0f, scale, (unsigned char *) surface->pixels, size, size, size * 4);
+    nsvgRasterize(rasterizer, image, 0.0f, 0.0f, scale, (unsigned char *) surface->pixels, size, size, size * 4);
     return surface;
 }
 

--- a/src/controllerimage.c
+++ b/src/controllerimage.c
@@ -183,7 +183,8 @@ int ControllerImage_AddData(const void *buf, size_t buflen)
     Uint16 version = 0;
 
     if (!DeviceInfoMap) {
-        return SDL_SetError("Not initialized");
+        SDL_SetError("Not initialized");
+        return -1;
     } else if (buflen < 20) {
         goto bogus_data;
     } else if (SDL_memcmp(magic, buf, sizeof (magic)) != 0) {
@@ -191,7 +192,8 @@ int ControllerImage_AddData(const void *buf, size_t buflen)
     } else if (!readui16(&ptr, &buflen, &version)) {
         return -1;
     } else if (version > CONTROLLERIMAGE_CURRENT_DATAVER) {
-        return SDL_SetError("Unsupported data version; upgrade your copy of ControllerImage?");
+        SDL_SetError("Unsupported data version; upgrade your copy of ControllerImage?");
+        return -1;
     } else if (!readui16(&ptr, &buflen, &num_strings)) {
         return -1;
     } else if ((strings = (char **) SDL_calloc(num_strings, sizeof (char *))) == NULL) {
@@ -262,7 +264,7 @@ int ControllerImage_AddData(const void *buf, size_t buflen)
             info->items[j].svg = strings[itemimage];
         }
 
-        if (SDL_SetPointerPropertyWithCleanup(DeviceInfoMap, strings[devid], info, CleanupDeviceInfo, NULL) == -1) {
+        if (!SDL_SetPointerPropertyWithCleanup(DeviceInfoMap, strings[devid], info, CleanupDeviceInfo, NULL)) {
             goto failed;
         }
 
@@ -319,7 +321,8 @@ int ControllerImage_AddDataFromIOStream(SDL_IOStream *iostrm, bool freeio)
     int retval = 0;
 
     if (!iostrm) {
-        return SDL_InvalidParamError("iostrm");
+        SDL_InvalidParamError("iostrm");
+        return -1;
     }
 
     buf = (Uint8 *) SDL_LoadFile_IO(iostrm, &buflen, freeio);

--- a/src/controllerimage.c
+++ b/src/controllerimage.c
@@ -565,6 +565,10 @@ static SDL_Surface *RasterizeImage(NSVGrasterizer *rasterizer, NSVGimage *image,
 
 SDL_Surface *ControllerImage_CreateSurfaceForAxis(ControllerImage_Device *device, SDL_GamepadAxis axis, int size)
 {
+    if (!device) {
+        SDL_InvalidParamError("device");
+        return NULL;
+    }
     const int iaxis = (int) axis;
     if ((iaxis < 0) || (iaxis >= SDL_GAMEPAD_AXIS_COUNT)) {
         SDL_InvalidParamError("axis");
@@ -580,6 +584,10 @@ SDL_Surface *ControllerImage_CreateSurfaceForAxis(ControllerImage_Device *device
 
 SDL_Surface *ControllerImage_CreateSurfaceForButton(ControllerImage_Device *device, SDL_GamepadButton button, int size)
 {
+    if (!device) {
+        SDL_InvalidParamError("device");
+        return NULL;
+    }
     const int ibutton = (int) button;
     if ((ibutton < 0) || (ibutton >= SDL_GAMEPAD_BUTTON_COUNT)) {
         SDL_InvalidParamError("button");
@@ -595,6 +603,10 @@ SDL_Surface *ControllerImage_CreateSurfaceForButton(ControllerImage_Device *devi
 
 const char *ControllerImage_GetSVGForAxis(ControllerImage_Device *device, SDL_GamepadAxis axis)
 {
+    if (!device) {
+        SDL_InvalidParamError("device");
+        return NULL;
+    }
     const int iaxis = (int) axis;
     if ((iaxis < 0) || (iaxis >= SDL_GAMEPAD_AXIS_COUNT)) {
         SDL_InvalidParamError("axis");
@@ -609,6 +621,10 @@ const char *ControllerImage_GetSVGForAxis(ControllerImage_Device *device, SDL_Ga
 
 const char *ControllerImage_GetSVGForButton(ControllerImage_Device *device, SDL_GamepadButton button)
 {
+    if (!device) {
+        SDL_InvalidParamError("device");
+        return NULL;
+    }
     const int ibutton = (int) button;
     if ((ibutton < 0) || (ibutton >= SDL_GAMEPAD_BUTTON_COUNT)) {
         SDL_InvalidParamError("button");

--- a/src/controllerimage.h
+++ b/src/controllerimage.h
@@ -54,12 +54,12 @@ extern SDL_DECLSPEC ControllerImage_Device * SDLCALL ControllerImage_CreateGamep
 
 extern SDL_DECLSPEC void SDLCALL ControllerImage_DestroyDevice(ControllerImage_Device *device);
 
-extern SDL_DECLSPEC const char *ControllerImage_GetDeviceType(ControllerImage_Device *device);
-extern SDL_DECLSPEC SDL_Surface *ControllerImage_CreateSurfaceForAxis(ControllerImage_Device *device, SDL_GamepadAxis axis, int size);
-extern SDL_DECLSPEC SDL_Surface *ControllerImage_CreateSurfaceForButton(ControllerImage_Device *device, SDL_GamepadButton button, int size);
+extern SDL_DECLSPEC const char * SDLCALL ControllerImage_GetDeviceType(ControllerImage_Device *device);
+extern SDL_DECLSPEC SDL_Surface * SDLCALL ControllerImage_CreateSurfaceForAxis(ControllerImage_Device *device, SDL_GamepadAxis axis, int size);
+extern SDL_DECLSPEC SDL_Surface * SDLCALL ControllerImage_CreateSurfaceForButton(ControllerImage_Device *device, SDL_GamepadButton button, int size);
 
-extern SDL_DECLSPEC const char *ControllerImage_GetSVGForAxis(ControllerImage_Device *device, SDL_GamepadAxis axis);
-extern SDL_DECLSPEC const char *ControllerImage_GetSVGForButton(ControllerImage_Device *device, SDL_GamepadButton button);
+extern SDL_DECLSPEC const char * SDLCALL ControllerImage_GetSVGForAxis(ControllerImage_Device *device, SDL_GamepadAxis axis);
+extern SDL_DECLSPEC const char * SDLCALL ControllerImage_GetSVGForButton(ControllerImage_Device *device, SDL_GamepadButton button);
 
 extern SDL_DECLSPEC void SDLCALL ControllerImage_Quit(void);
 

--- a/src/test-controllerimage.c
+++ b/src/test-controllerimage.c
@@ -67,7 +67,7 @@ static int load_artset(const char *artset)
         panic("ControllerImage_CreateGamepadDeviceByIdString failed!", SDL_GetError());
         return -1;
     }
-    if (SDL_SetPointerPropertyWithCleanup(artset_properties, PROP_IMGDEV, imgdev, cleanup_imgdev, NULL) < 0) {
+    if (!SDL_SetPointerPropertyWithCleanup(artset_properties, PROP_IMGDEV, imgdev, cleanup_imgdev, NULL)) {
         panic("SDL_SetPointerPropertyWithCleanup failed!", SDL_GetError());
         return -1;
     }


### PR DESCRIPTION
This updates more return value handling for SDL3 stable API and fixes dereferencing NULL device passed from the application to the ControllerImage API functions. (The demo can do this if controllerimage-standard.bin is missing.)

This also adds SDLCALL to ControllerImage API functions that were missing it and replaces stray tabs with spaces that existed before this PR.